### PR TITLE
Dialogue handling improvements

### DIFF
--- a/dist/SKSE/Plugins/mfgfix.ini
+++ b/dist/SKSE/Plugins/mfgfix.ini
@@ -279,3 +279,9 @@ fEyeOffsetDelayMinEmotionCombatShout = 3.000000
 ; Eyes movement delay in seconds (maximum).
 ; Default: 3.0
 fEyeOffsetDelayMaxEmotionCombatShout = 3.000000
+
+[Dialogue]
+; Minimum phoneme value applied during dialogue.
+; Values below this threshold are ignored.
+; Default: 50
+fDialoguePhonemeThreshold = 50

--- a/dist/source/scripts/MfgConsoleFuncExt.psc
+++ b/dist/source/scripts/MfgConsoleFuncExt.psc
@@ -85,7 +85,7 @@ Scriptname MfgConsoleFuncExt Hidden
 ;        =Arguments=
 ;akActor            = actor to process
 ;apExpression       = raw expression construct.
-;abOpenMouth        = if true, will skip phonems
+;abOpenMouth        = if true, will skip phonemes
 ;exprPower          = used if expression is set but expr value is 0 in the preset (dynamic expr strength). 0 to ignore
 ;exprStrModifier, modStrModifier,  phStrModifier= values will be miltiplied by those (capped by 200)
 ;speed              = anim speed. 0.1 is close to instant. 0.75 is recomended for smooth transitions 
@@ -116,6 +116,9 @@ bool function SetPhonemeModifierSmooth(Actor act, int mode, int id, int value, f
 
 ; Get PC dialogue target
 Actor Function GetPlayerSpeechTarget() global native
+
+;Works for NPCs and Player for regular dialogues and chatter also like greetings and bumps. Using dialoguedata object
+bool Function IsInDialogue(Actor akActor) global native
 
 ; wrapper functions
 

--- a/src/mfgfix/BSFaceGenAnimationData.cpp
+++ b/src/mfgfix/BSFaceGenAnimationData.cpp
@@ -380,7 +380,19 @@ namespace MfgFix
 			DialoguePhonemesUpdate(a_timeDelta);
 
 			merge(phoneme1, phoneme3);
-			merge(phoneme2, phoneme3);
+			if (dialogueData) {
+				auto threshold = Settings::Get().dialogue.fDialoguePhonemeThreshold;
+				auto count = min(phoneme2.count, phoneme3.count);
+				for (std::uint32_t i = 0; i < count; ++i) {
+					if (phoneme2.values[i] >= threshold) {
+						phoneme3.values[i] = phoneme2.values[i];
+					} else {
+						phoneme2.values[i] = 0.0f;
+					}
+				}
+			} else {
+				merge(phoneme2, phoneme3);
+			}
 		}
 
 		// custom
@@ -500,7 +512,17 @@ namespace MfgFix
 		DialoguePhonemesUpdate(a_timeDelta);
 
 		// phonemes
-		animMerge(phoneme1, phoneme2, phoneme3);
+		if (dialogueData) {
+			auto threshold = Settings::Get().dialogue.fDialoguePhonemeThreshold;
+			for (std::uint32_t i = 0; i < phoneme2.count; ++i) {
+				if (phoneme2.values[i] < threshold) {
+					phoneme2.values[i] = 0.0f;
+				}
+			}
+			animMerge(phoneme1, phoneme2, phoneme3);
+		} else {
+			animMerge(phoneme1, phoneme2, phoneme3);
+		}
 		// custom
 		animMerge(custom1, custom2, custom3);
 	}

--- a/src/mfgfix/MfgConsoleFunc.cpp
+++ b/src/mfgfix/MfgConsoleFunc.cpp
@@ -1,6 +1,7 @@
 ﻿#include "MfgConsoleFunc.h"
 #include "BSFaceGenAnimationData.h"
 #include "ActorManager.h"
+#include "Settings.h"
 
 namespace MfgFix::MfgConsoleFunc
 {
@@ -14,6 +15,16 @@ namespace MfgFix::MfgConsoleFunc
 			ExpressionValue,
 			ExpressionId
 		};
+
+		static bool IsInDialogue(RE::Actor* a_actor)
+		{
+			if (!a_actor) {
+				return false;
+			}
+
+			auto animData = reinterpret_cast<BSFaceGenAnimationData*>(a_actor->GetFaceGenAnimationData());
+			return animData && animData->dialogueData;
+		}
 	}
 
 	inline bool SetPhoneme(BSFaceGenAnimationData* animData, std::uint32_t a_id, std::int32_t a_value)
@@ -325,6 +336,11 @@ namespace MfgFix::MfgConsoleFunc
 		return nullptr;
 	}
 
+	bool IsInDialoguePapyrus(RE::StaticFunctionTag*, RE::Actor* a_actor)
+	{
+		return IsInDialogue(a_actor);
+	}
+
 
 
 	void Register()
@@ -336,7 +352,7 @@ namespace MfgFix::MfgConsoleFunc
 			a_vm->RegisterFunction("ResetMFGSmooth", "MfgConsoleFuncExt", ResetMFGSmooth);
 			a_vm->RegisterFunction("ApplyExpressionPreset", "MfgConsoleFuncExt", ApplyExpressionPreset);
 			a_vm->RegisterFunction("GetPlayerSpeechTarget", "MfgConsoleFuncExt", GetPlayerSpeechTarget);
-
+			a_vm->RegisterFunction("IsInDialogue", "MfgConsoleFuncExt", IsInDialoguePapyrus);
 			return true;
 		});
 	}

--- a/src/mfgfix/Settings.cpp
+++ b/src/mfgfix/Settings.cpp
@@ -106,6 +106,7 @@ namespace MfgFix
 		eyesMovement.fEyePitchMaxOffsetEmotionCombatShout = static_cast<float>(ini.GetDoubleValue("EyesMovement", "fEyePitchMaxOffsetEmotionCombatShout", eyesMovement.fEyePitchMaxOffsetEmotionCombatShout));
 		eyesMovement.fEyeOffsetDelayMinEmotionCombatShout = static_cast<float>(ini.GetDoubleValue("EyesMovement", "fEyeOffsetDelayMinEmotionCombatShout", eyesMovement.fEyeOffsetDelayMinEmotionCombatShout));
 		eyesMovement.fEyeOffsetDelayMaxEmotionCombatShout = static_cast<float>(ini.GetDoubleValue("EyesMovement", "fEyeOffsetDelayMaxEmotionCombatShout", eyesMovement.fEyeOffsetDelayMaxEmotionCombatShout));
+		dialogue.fDialoguePhonemeThreshold = static_cast<float>(ini.GetDoubleValue("Dialogue", "fDialoguePhonemeThreshold", dialogue.fDialoguePhonemeThreshold));
 	}
 
 	void Settings::Write()
@@ -185,7 +186,7 @@ namespace MfgFix
 		ini.SetDoubleValue("EyesMovement", "fEyePitchMaxOffsetEmotionCombatShout", eyesMovement.fEyePitchMaxOffsetEmotionCombatShout);
 		ini.SetDoubleValue("EyesMovement", "fEyeOffsetDelayMinEmotionCombatShout", eyesMovement.fEyeOffsetDelayMinEmotionCombatShout);
 		ini.SetDoubleValue("EyesMovement", "fEyeOffsetDelayMaxEmotionCombatShout", eyesMovement.fEyeOffsetDelayMaxEmotionCombatShout);
-
+		ini.SetDoubleValue("Dialogue", "fDialoguePhonemeThreshold", dialogue.fDialoguePhonemeThreshold);
 		ini.SaveFile(path.c_str());
 	}
 }

--- a/src/mfgfix/Settings.h
+++ b/src/mfgfix/Settings.h
@@ -84,6 +84,11 @@ namespace MfgFix
 			float	fEyeOffsetDelayMaxEmotionCombatShout{ 3.0f };
 		};
 
+		struct Dialogue
+		{
+			float fDialoguePhonemeThreshold{ 50.0f };
+		};
+
 		static Settings&	Get();
 
 		void	Read();
@@ -92,5 +97,7 @@ namespace MfgFix
 		Transition		transition;
 		EyesBlinking	eyesBlinking;
 		EyesMovement	eyesMovement;
+		Dialogue dialogue;
+
 	};
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -5,7 +5,7 @@ PROJECT_NAME = "mfgfix"
 
 -- Project
 set_project(PROJECT_NAME)
-set_version("1.0.3")
+set_version("1.0.4")
 set_languages("cxx23")
 set_license("gplv3")
 set_warnings("allextra", "error")


### PR DESCRIPTION
A new setting fDialoguePhonemeThreshold under the Configuration section for controlling dialogue phoneme handling During regular updates, phonemes from dialogue below the threshold are ignored before merging Smooth updates also zero out phonemes below the threshold to achieve the same effect Main goal to not stuck in weird mouth shapes if both modifiers and dialogue is happening, Significant values are still respected - e.g. for dd gags.

A new papyrus function added IsInDialogue(Actor)