### PR TITLE
WIP: eye fix try 2 

### DIFF
--- a/src/mfgfix/BSFaceGenAnimationData.cpp
+++ b/src/mfgfix/BSFaceGenAnimationData.cpp
@@ -462,10 +462,10 @@ namespace MfgFix
 			EyesBlinkingUpdate(a_timeDelta, false);
 
 			if (!unk21A) {
-				modifier3.values[Modifier::LookLeft] += eyesHeading < 0.0f ? -eyesHeading / eyesHeadingMax : 0.0f;
-				modifier3.values[Modifier::LookRight] += eyesHeading > 0.0f ? eyesHeading / eyesHeadingMax : 0.0f;
-				modifier3.values[Modifier::LookDown] += eyesPitch < 0.0f ? -eyesPitch / eyesPitchMax : 0.0f;
-				modifier3.values[Modifier::LookUp] += eyesPitch > 0.0f ? eyesPitch / eyesPitchMax : 0.0f;
+				modifier3.values[Modifier::LookLeft] -= eyesHeading < 0.0f ? -eyesHeading / eyesHeadingMax : 0.0f;
+				modifier3.values[Modifier::LookRight] -= eyesHeading > 0.0f ? eyesHeading / eyesHeadingMax : 0.0f;
+				modifier3.values[Modifier::LookDown] -= eyesPitch < 0.0f ? -eyesPitch / eyesPitchMax : 0.0f;
+				modifier3.values[Modifier::LookUp] -= eyesPitch > 0.0f ? eyesPitch / eyesPitchMax : 0.0f;
 
 				EyesMovementUpdate(a_timeDelta);
 			}


### PR DESCRIPTION
(Now with Claude)
The linter "fixed" the inconsistency between LookLeft/LookRight and LookDown/LookUp — but in the wrong direction. Now all four are wrong: all add the tracking contribution instead of subtracting it.

Why all four should subtract
The structure of SmoothUpdate's modifier block is:

Pre-merge: strip tracking out of modifier3 (which carries the previous frame's final result), so animMerge works only on the dialogue/console portion
animMerge: smoothly animate the dialogue portion toward modifier2
Post-merge: re-add tracking on top via currentHeading/currentPitch (lines 502–512)
With += positive_tracking (current state), each frame adds instead of strips tracking from modifier3, so animMerge starts from (previous_result + current_tracking) and tries to drain toward 0 — it can't keep up, creating the feedback loop that locks eyes to an extreme direction.

The fix is consistent -= across all four: