### PR TITLE
Fix/stale dialogue modifiers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# Mfg Fix NG
+
+Skyrim SE SKSE plugin: extended facial animation/expression system with smooth transitions, eye blinking/movement, and Papyrus API. C++ plugin built on CommonLibSSE-NG. Version-independent (SE/AE/VR) via RelocationID hooks.
+
+## Build
+
+```sh
+# xmake 2.9.5+, MSVC v143 (VS 2022), C++23
+# Env vars: XSE_TES5_GAME_PATH (SSE install), XSE_TES5_MODS_PATH (MO2 mods folder)
+git submodule update --init --recursive
+xmake f -m release && xmake        # -> dist/SKSE/Plugins/mfgfix.dll
+```
+
+Post-build compiles Papyrus scripts via `XSE_TES5_GAME_PATH/Papyrus Compiler/`, copies to `dist/SKSE/Plugins/`, and optionally copies to MO2 mod folder.
+
+## Dependencies
+
+- CommonLibSSE-NG (submodule at `lib/commonlibsse-ng`)
+- Microsoft Detours (submodule at `lib/detours`)
+- SimpleINI, DirectXTK (xmake packages)
+
+## Project Structure
+
+```
+src/
+  main.cpp                          SKSE entry point -> MfgFix::Init()
+  PCH.h                             Precompiled header
+  mfgfix/
+    mfgfixinit.cpp/.h               Init orchestrator: hooks, patches, registration
+    BSFaceGenAnimationData.cpp/.h    Core: animation update hook, transitions, blinking, eye movement
+    BSFaceGenKeyframe.h              Abstract keyframe base class
+    BSFaceGenKeyframeMultiple.cpp/.h Keyframe impl (float arrays for expressions/modifiers/phonemes)
+    Settings.cpp/.h                  INI config singleton (transition speed, blink timing, eye movement)
+    SettingsPapyrus.cpp/.h           Papyrus bindings for settings read/write
+    ConsoleCommands.cpp/.h           Console SetValue/PrintInfo for keyframe manipulation
+    MfgConsoleFunc.cpp/.h            Papyrus native functions (phoneme/modifier/expression get/set)
+    ActorManager.h                   Per-actor animation speed map (FormID -> speed)
+    Offsets.h                        RelocationID mappings for all hooked functions
+dist/
+  source/scripts/
+    MfgConsoleFunc.psc               Native wrappers: Get/SetPhonemeModifier, expression queries
+    MfgConsoleFuncExt.psc            Extended API: smooth transitions, ApplyExpressionPreset, ResetMFGSmooth
+  scripts/                           Compiled .pex output
+  SKSE/Plugins/                      Compiled .dll output
+```
+
+## Core Systems
+
+### 1. Keyframe Blending & Update Hook
+
+`BSFaceGenAnimationData::KeyframesUpdateHook()` is the main tick. Three keyframe layers per category (expression, modifier, phoneme, custom):
+- `keyframe1`: dialogue-driven values
+- `keyframe2`: user/console/Papyrus-set values
+- `keyframe3`: final blended output
+
+Linear interpolation blends layers. Transition speed per-actor via `ActorManager`.
+
+### 2. Expression System
+
+17 expressions: 7 dialogue, 7 mood, 3 combat. Values stored as 0.0-1.0 floats internally; Papyrus API uses 0-200 integer scale (divided by 200). Smooth transitions interpolate between `transitionTarget` and `expression3`.
+
+### 3. Eye Blinking
+
+6-stage state machine (closed -> opening -> open -> delay -> closing -> closed). Configurable blink down/up times and random delay range via INI settings.
+
+### 4. Eye Movement
+
+Emotion-aware eye offsets with per-mood heading/pitch ranges. Random target selection with configurable delay timers.
+
+### 5. Dialogue System
+
+Tracks `dialogueData`; applies modifier/phoneme interpolation from dialogue-specific keyframes. Spinlock-protected for thread safety.
+
+### 6. Binary Patches
+
+Applied in `mfgfixinit.cpp`:
+- Fixes expression changes on dead NPCs (NOPs dead-NPC expression blocks)
+- Fixes `SetExpressionOverride` mood 0 handling
+- Disables null parent node crash in eye animation code
+
+## Code Conventions
+
+- Thread-safe access via `RE::BSSpinLock` on `BSFaceGenAnimationData`
+- All values clamped to 0.0-1.0 range in storage
+- Console variable `mfgfixng` for runtime setting adjustments
+- spdlog-based logging; debug builds log to MSVC output, release to file
+- RelocationID-based hooking for version independence (SE/AE/VR)
+
+## Papyrus API
+
+**MfgConsoleFunc** (native): `SetPhonemeModifier(actor, type, id, value)`, `GetPhonemeModifier(actor, type, id)` where type 0=phoneme, 1=modifier, 2=expression. Value 0-200 (0-100 normal range; 101-200 allowed for exaggerated morphs).
+
+**MfgConsoleFuncExt** (Papyrus): Smooth animation wrappers, `ApplyExpressionPreset(actor, float[32])` where the 32-element array is [16 phonemes (0.0-1.0), 14 modifiers (0.0-1.0), expressionID (0-16), strength (0.0-1.0)]. `ResetMFGSmooth(actor, mode, speed)` for smooth reset.

--- a/SMOKE_TESTS.md
+++ b/SMOKE_TESTS.md
@@ -1,0 +1,147 @@
+# Mfg Fix NG -- AI Smoke Tests
+
+Pre-release checklist. Each scenario should be verified in-game or by code inspection before tagging a release.
+
+**Priority key:** P0 = blocker, P1 = high, P2 = medium
+
+---
+
+## 1. Plugin Loading & Initialization
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 1.1 | P0 | Game starts with plugin installed | `SKSEPluginLoad` succeeds, logger initialized, `MfgFix::Init()` called | main.cpp |
+| 1.2 | P0 | Detour hooks attached | `KeyframesUpdateHook` and `ModifyFaceGenCommandHook` detours both report `NO_ERROR` in log | BSFaceGenAnimationData::Init, ConsoleCommands::Init |
+| 1.3 | P0 | Papyrus functions registered | `MfgConsoleFunc` and `MfgConsoleFuncExt` bindings available to scripts | MfgConsoleFunc::Register |
+| 1.4 | P0 | INI settings loaded | `mfgfix.ini` read on init; blink timing, eye movement, transition speed populated | Settings::Read |
+| 1.5 | P1 | Binary patches applied | Dead-NPC expression NOP, SetExpressionOverride mood-0 fix, null parent node crash prevention all applied | mfgfixinit.cpp |
+| 1.6 | P1 | VR build path | All `REL::Module::IsVR()` branches use correct offsets; no SE/AE relocations used on VR | All files |
+
+## 2. Keyframe Blending -- Regular Update (speed = 0)
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 2.1 | P0 | Expression merge | `expression3` built from `expression1` (dialogue/override) then `expression2` (user); non-zero source wins | RegularUpdate |
+| 2.2 | P0 | Modifier merge order | `modifier3` reset, then blink + dialogue modifiers, then `merge(modifier1, modifier3)`, then eye direction, then `merge(modifier2, modifier3)` | RegularUpdate |
+| 2.3 | P0 | Phoneme merge with dialogue active | `phoneme2` values below `fDialoguePhonemeThreshold` zeroed; above-threshold values override `phoneme3` | RegularUpdate |
+| 2.4 | P1 | Phoneme merge without dialogue | Standard non-zero merge from `phoneme2` into `phoneme3` (no threshold filtering) | RegularUpdate |
+| 2.5 | P1 | Spinlock held during entire update | `RE::BSSpinLockGuard` acquired at top, released at end; no data races | RegularUpdate |
+
+## 3. Keyframe Blending -- Smooth Update (speed > 0)
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 3.1 | P0 | animMerge interpolation | For each value: dialogue direct-copy when modifier ~0, snap when within step, else step toward modifier | SmoothUpdate |
+| 3.2 | P0 | Blink overlay math | Pre-blink undo (divide out previous blinkValue), post-blink apply (multiply in current blinkValue), `else` branch for near-1.0 avoids divide-by-zero | SmoothUpdate |
+| 3.3 | P1 | Per-actor speed | `ActorManager::GetSpeed` returns actor-specific speed; `animationStep = timeDelta / speed` scales smoothing rate | SmoothUpdate, ActorManager |
+| 3.4 | P1 | Eye direction smooth update | Eye heading/pitch clamped to `fTrackEyeXY`/`fTrackEyeZ` range, rate-limited by `fTrackSpeed * timeDelta` | SmoothUpdate |
+| 3.5 | P2 | Operator precedence in animMerge | `i >= modifier.count || fabs(modifier.values[i]) < FLT_EPSILON && fabs(dialogue.values[i]) > FLT_EPSILON` -- `&&` binds before `||`; verify this is intentional (dialogue fallback only when modifier ~0 AND dialogue non-zero) | SmoothUpdate |
+
+## 4. Eye Blinking
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 4.1 | P0 | Normal blink cycle | `BlinkDelay` (random 0.5-8s) -> `BlinkDown` (0.04s) -> `BlinkUp` (0.14s) -> repeat | EyesBlinkingUpdate |
+| 4.2 | P0 | blinkValue clamped | `std::clamp(blinkValue, 0.0f, 1.0f)` applied after switch | EyesBlinkingUpdate |
+| 4.3 | P1 | BlinkDownAndWait1 with unk21A=true | Eyes close and stay closed while `unk21A` is true; no timer-expiry transition (intentional hold for headtracking) | EyesBlinkingUpdate |
+| 4.4 | P1 | BlinkDownAndWait1 with unk21A=false | `blinkValue = 1.0`, transitions to `BlinkUp` with `fBlinkUpTime` timer | EyesBlinkingUpdate |
+| 4.5 | P1 | Default/unknown stage | Resets to `BlinkDelay` with random timer; `blinkValue = 0` | EyesBlinkingUpdate |
+| 4.6 | P2 | Zero blink times | `fBlinkDownTime = 0` -> `blinkValue = 1.0` (instant close); `fBlinkUpTime = 0` -> `blinkValue = 0.0` (instant open) | EyesBlinkingUpdate |
+
+## 5. Eye Movement
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 5.1 | P1 | Emotion-aware offsets | Each of 10 expression pairs (dialogue+mood) uses its own heading/pitch/delay ranges from settings | EyesMovementUpdate |
+| 5.2 | P1 | Disabled during headtracking | `!unk21A` gate prevents eye movement and direction updates during dialogue camera lock | RegularUpdate, SmoothUpdate |
+| 5.3 | P2 | Fear emotion 50% chance | `rand(0,1) <= 0.5` chance to zero out heading/pitch offsets for fear | EyesMovementUpdate |
+| 5.4 | P2 | LookLeft/Right/Down/Up clamped 0-1 | Final modifier3 look values clamped in SmoothUpdate eye direction block | SmoothUpdate |
+
+## 6. Dialogue System
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 6.1 | P0 | Active dialogue updates modifiers | `DialogueModifiersUpdate` calls `sub_1FCD10` with `modifier1.timer`, writes to `modifier1.values` | DialogueModifiersUpdate |
+| 6.2 | P0 | Active dialogue updates phonemes | `DialoguePhonemesUpdate` calls `sub_1FC9B0` with `phoneme1.timer`, writes to `phoneme1.values` | DialoguePhonemesUpdate |
+| 6.3 | P0 | **Stale modifier cleanup (FIX)** | When `modifier1.timer > animEnd`, `modifier1.Reset()` called and interpolation skipped; prevents eyes stuck closed from trailing WAV silence | DialogueModifiersUpdate |
+| 6.4 | P0 | **Stale phoneme cleanup (FIX)** | Same as 6.3 for `phoneme1` | DialoguePhonemesUpdate |
+| 6.5 | P0 | Dialogue data release | `CheckAndReleaseDialogueData` releases when `phoneme1.timer > animEnd + 0.2s`; `modifier1.Reset()` + `phoneme1.Reset()` before nulling pointer | CheckAndReleaseDialogueData |
+| 6.6 | P1 | Reset() preserves timer | `Reset()` zeros `values[]` and `isUpdated` only; `timer` field untouched so `CheckAndReleaseDialogueData` timer comparison still works | BSFaceGenKeyframeMultiple::Reset |
+| 6.7 | P1 | refCount gating | Both dialogue update functions and `CheckAndReleaseDialogueData` return early when `dialogueData` is null or refCount check fails | All three functions |
+| 6.8 | P1 | animEnd calculation | `(unk0 + abs(unk4 if negative)) * 0.033f` matches FaceFX frame-to-seconds conversion; consistent between DialogueModifiers/Phonemes and CheckAndRelease (+0.2s grace) | DialogueModifiersUpdate, CheckAndReleaseDialogueData |
+
+## 7. Expression Transitions
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 7.1 | P0 | TransitionUpdate | `expression1.TransitionUpdate(timeDelta, transitionTarget)` interpolates toward target each frame | RegularUpdate, SmoothUpdate |
+| 7.2 | P1 | SetExpressionOverride | Clears `expressionOverride`, calls engine function, re-enables override; expression1 updated | SetExpressionOverride, ConsoleCommands::SetValue |
+| 7.3 | P2 | 17 expressions valid | Indices 0-16 map to 7 dialogue + 7 mood + 3 combat expressions | BSFaceGenKeyframeMultiple::Expression |
+
+## 8. Console Commands
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 8.1 | P0 | `mfg expression <id> <value>` | Sets expression override on selected actor; value divided by 100 | ConsoleCommands |
+| 8.2 | P0 | `mfg modifier <id> <value>` | Sets `modifier2` value on selected actor | ConsoleCommands |
+| 8.3 | P0 | `mfg phoneme <id> <value>` | Sets `phoneme2` value on selected actor | ConsoleCommands |
+| 8.4 | P0 | `mfg reset` | Clears expression override, calls `Reset(0, true, true, true, false)` | ConsoleCommands |
+| 8.5 | P1 | `mfg expression` (no args) | Prints all expression values to console | ConsoleCommands::PrintInfo |
+| 8.6 | P1 | `mfg custom <id> <value>` | Sets `custom2` value on selected actor | ConsoleCommands |
+| 8.7 | P2 | No selected actor | Falls back to `RE::PlayerCharacter::GetSingleton()` | ConsoleCommands |
+
+## 9. Papyrus API
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 9.1 | P0 | `SetPhonemeModifier(actor, type, id, value)` | Dispatches via UI task; type 0=phoneme (0-15), 1=modifier (0-13), 2=expression (0-16); value 0-200 | MfgConsoleFunc |
+| 9.2 | P0 | `GetPhonemeModifier(actor, type, id)` | Returns current value * 100; -1 on invalid actor/animData | MfgConsoleFunc |
+| 9.3 | P0 | `SetPhonemeModifierSmooth(actor, type, id, value, speed)` | Same as SetPhonemeModifier but sets `ActorManager::SetSpeed` for smooth transitions | MfgConsoleFunc |
+| 9.4 | P1 | `ApplyExpressionPreset(actor, float[32], ...)` | 32-element vector: [0-15] phonemes, [16-29] modifiers, [30] exprID, [31] strength; applies via UI task | MfgConsoleFunc |
+| 9.5 | P1 | `ResetMFGSmooth(actor, mode, speed)` | mode -1=all, 0=phonemes, 1=modifiers; clears values then resets | MfgConsoleFunc |
+| 9.6 | P1 | `GetPlayerSpeechTarget()` | Returns current dialogue partner via `MenuTopicManager::speaker` | MfgConsoleFunc |
+| 9.7 | P1 | `IsInDialogue(actor)` | Returns true when `animData->dialogueData` is non-null | MfgConsoleFunc |
+| 9.8 | P2 | Value clamping | All set functions clamp input to 0-200 before dividing by 100 (storage range 0.0-2.0) | MfgConsoleFunc |
+
+## 10. Settings & Configuration
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 10.1 | P1 | INI read/write | `Settings::Read()` / `Settings::Write()` persist all settings to `mfgfix.ini` via SimpleINI | Settings.cpp |
+| 10.2 | P1 | Papyrus settings bindings | `SettingsPapyrus` exposes get/set for blink timing, eye movement, transition speed to Papyrus scripts | SettingsPapyrus.cpp |
+| 10.3 | P2 | Default values | `fBlinkDownTime=0.04`, `fBlinkUpTime=0.14`, `fBlinkDelayMin=0.5`, `fBlinkDelayMax=8.0`, `fDefaultSpeed=0.0`, `fDialoguePhonemeThreshold=50.0` | Settings.h |
+
+## 11. Binary Patches
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 11.1 | P0 | Dead NPC expression fix | NOP bytes at `sub_3DB770 + 0x4B` (9 or 13 bytes depending on version) allow expression changes on dead NPCs | mfgfixinit.cpp |
+| 11.2 | P0 | SetExpressionOverride mood 0 fix | Two patches at `Papyrus::Actor::SetExpressionOverride` fix mood index 0 (neutral) handling | mfgfixinit.cpp |
+| 11.3 | P1 | Null parent node crash prevention | 15 NOP bytes at `BSFaceGenNiNode::sub_3F0C90 + 0x2E3/0x395` disable crash-prone eye animation code | mfgfixinit.cpp |
+| 11.4 | P1 | Eye update relocation | `BSFaceGenNiNode::sub_3F1800 + 0x139` short-jump (0x47EB) removes eyes update from `UpdateDownwardPass` (moved to KeyframesUpdate hook) | BSFaceGenAnimationData::Init |
+
+## 12. Thread Safety
+
+| # | P | Scenario | Expected | Source |
+|---|---|----------|----------|--------|
+| 12.1 | P0 | Update functions hold spinlock | `RegularUpdate` and `SmoothUpdate` both acquire `RE::BSSpinLockGuard(lock)` at entry | RegularUpdate, SmoothUpdate |
+| 12.2 | P0 | Console commands hold spinlock | `SetValue`, `PrintInfo`, `Reset` all acquire spinlock before accessing animData | ConsoleCommands |
+| 12.3 | P1 | Papyrus UI task dispatch | `SetPhonemeModifierSmooth`, `ApplyExpressionPreset`, `ResetMFGSmooth` all execute via `SKSE::GetTaskInterface()->AddUITask` with spinlock inside | MfgConsoleFunc |
+| 12.4 | P1 | CheckAndReleaseDialogueData outside lock | Runs after `SmoothUpdate`/`RegularUpdate` release lock; modifies `dialogueData` pointer without lock -- safe because hook replaces the only caller | KeyframesUpdateHook |
+
+---
+
+## 13. Known Issues & Fragile Areas
+
+| # | P | Issue | Location | Impact |
+|---|---|-------|----------|--------|
+| 13.1 | ~P0~ | ~~**Stale dialogue modifiers -- eyes stuck closed** after dialogue lines with trailing WAV silence past FaceFX end~~ **FIXED** -- `DialogueModifiersUpdate`/`DialoguePhonemesUpdate` now clear values and skip interpolation when timer > animEnd; `CheckAndReleaseDialogueData` resets both on release | BSFaceGenAnimationData.cpp | Eyes no longer stuck shut after dialogue |
+| 13.2 | ~P2~ | ~~**animMerge operator precedence** -- missing parentheses made intent unclear~~ **FIXED** -- added explicit parens around `&&` clause; no behavior change | SmoothUpdate | Clarity improvement only |
+| 13.3 | ~P2~ | ~~**BlinkDownAndWait1 stuck state** -- when `unk21A` is true and `eyesBlinkingTimer` reaches 0, no stage transition occurs~~ **FIXED** -- added timer-expiry transition to `BlinkUp` when `unk21A` is true, matching `BlinkDown` behavior. Defensive fix; stage only reachable if the engine externally sets `eyesBlinkingStage` | EyesBlinkingUpdate | Eyes no longer stuck if stage is entered during headtracking |
+| 13.4 | ~P2~ | ~~**ActorManager forward declaration** -- `ActorManager.h` references `BSFaceGenAnimationData*` without forward declaration~~ **FIXED** -- added `class BSFaceGenAnimationData;` forward declaration in `ActorManager.h` | ActorManager.h | Build no longer depends on include order |
+| 13.5 | ~~ | ~~**Modifier range check inconsistency** -- `SetModifier` bounds-checks `a_id > 13` but enum defines 17 modifiers (0-16)~~ **BY DESIGN** -- HeadPitch/Roll/Yaw (14-16) are engine-controlled via headtracking; allowing script writes would fight the engine every frame. Range 0-13 is the correct script-accessible subset | MfgConsoleFunc | Not a bug |
+| 13.6 | ~P2~ | ~~**Phoneme value scale mismatch** -- `SetValue` clamps to 0-200 and divides by 100 (max 2.0), but `IsValueValid` checks range [0, 1]~~ **BY DESIGN** -- `IsValueValid` is an engine vtable stub never called by the mod; 0-200 range is intentional for exaggerated morphs. API docs updated to document full range | MfgConsoleFunc, BSFaceGenKeyframeMultiple | Not a bug |
+
+---
+
+*Last updated: 2026-04-27*

--- a/dist/source/scripts/MfgConsoleFunc.psc
+++ b/dist/source/scripts/MfgConsoleFunc.psc
@@ -1,6 +1,8 @@
 Scriptname MfgConsoleFunc Hidden
 
-; native functions, wrapper base. these have magic number for select some parameter.
+; Native functions. mode: -1=reset, 0=phoneme, 1=modifier, 2=expression value, 3=expression id (get only).
+; value: [ 0 , 200 ] — 0 to 100 is the normal range; 101-200 is allowed and may produce exaggerated morphs.
+; GetPhonemeModifier returns the current value in 0-100 scale, or -1 on error.
 bool function SetPhonemeModifier(Actor act, int mode, int id, int value) native global
 int function GetPhonemeModifier(Actor act, int mode, int id) native global
 

--- a/dist/source/scripts/MfgConsoleFuncExt.psc
+++ b/dist/source/scripts/MfgConsoleFuncExt.psc
@@ -108,8 +108,8 @@ bool function ResetMFGSmooth(Actor akActor, int mode, float speed) native global
 ;akActor            = actor to process
 ;mode        		=  Reset= -1,Phoneme= 0,Modifier= 1,ExpressionValue = 2,
 ;id                 = phoneme or modifier or mood id
-;value              = phoneme or modifier or expression strength
-;speed              = anim speed. 0.1 is close to instant. 0.75 is recomended for smooth transitions 
+;value              = phoneme or modifier or expression strength [ 0 , 200 ] — 0 to 100 is the normal range; 101-200 is allowed and may produce exaggerated morphs.
+;speed              = anim speed. 0.1 is close to instant. 0.75 is recomended for smooth transitions
 ;        =Return value=
 ;Return true if successfully applied
 bool function SetPhonemeModifierSmooth(Actor act, int mode, int id, int value, float speed) native global

--- a/docs/dialogue-modifier-lifecycle.md
+++ b/docs/dialogue-modifier-lifecycle.md
@@ -1,0 +1,131 @@
+# Dialogue Modifier Lifecycle
+
+Data flow through the facial animation system during dialogue, showing how
+`modifier1`/`phoneme1` values are produced, consumed, and cleared.
+
+## 1. Active FaceFX (timer <= animEnd)
+
+```
+KeyframesUpdateHook
+  +-- SmoothUpdate / RegularUpdate
+  |     +-- DialogueModifiersUpdate
+  |     |     +-- dialogueData valid, refCount OK -> proceed
+  |     |     +-- modifier1.timer += timeDelta
+  |     |     +-- timer <= animEnd -> call sub_1FCD10
+  |     |     +-- modifier1.values <- fresh animation data (blinks, brows, etc.)
+  |     |
+  |     +-- DialoguePhonemesUpdate
+  |     |     +-- (same pattern -> phoneme1.values <- lip sync data)
+  |     |
+  |     +-- EyesBlinkingUpdate -> blinkValue into modifier3 or modifier2.timer
+  |     |
+  |     +-- merge/animMerge(modifier1, modifier2, modifier3)
+  |     |     +-- modifier1 blink values override blinking system (intended)
+  |     |
+  |     +-- final modifier3 -> rendered face
+```
+
+FaceFX interpolation provides live modifier/phoneme data each frame.
+The merge logic lets dialogue-driven blinks and expressions take priority
+over the procedural blinking system.
+
+## 2. Trailing WAV silence (timer > animEnd, dialogueData still alive)
+
+### Before (bug)
+
+```
+KeyframesUpdateHook
+  +-- SmoothUpdate / RegularUpdate
+  |     +-- DialogueModifiersUpdate
+  |     |     +-- dialogueData valid, refCount OK -> proceed
+  |     |     +-- modifier1.timer += timeDelta
+  |     |     +-- call sub_1FCD10 (timer past FaceFX end)
+  |     |     +-- modifier1.values <- STALE last-frame data (BlinkLeft/Right != 0)
+  |     |
+  |     +-- DialoguePhonemesUpdate
+  |     |     +-- (same -> phoneme1.values <- stale lip sync data)
+  |     |
+  |     +-- EyesBlinkingUpdate -> blinkValue computed normally
+  |     |
+  |     +-- merge/animMerge(modifier1, modifier2, modifier3)
+  |     |     +-- modifier1 blink values != 0 -> OVERRIDE blinking system
+  |     |     +-- eyes forced shut by stale dialogue data
+  |     |
+  |     +-- final modifier3 -> eyes stuck closed
+```
+
+`sub_1FCD10` returns the last FaceFX frame's values for any time past the
+animation end. If that frame has non-zero BlinkLeft/BlinkRight, the merge
+logic treats them as live dialogue data and overrides the blinking system
+every tick. Eyes remain shut for the entire trailing silence and beyond
+(values are never cleared).
+
+### After (fix)
+
+```
+KeyframesUpdateHook
+  +-- SmoothUpdate / RegularUpdate
+  |     +-- DialogueModifiersUpdate
+  |     |     +-- dialogueData valid, refCount OK -> proceed
+  |     |     +-- modifier1.timer += timeDelta
+  |     |     +-- timer > animEnd -> modifier1.Reset(), return   <-- FIX
+  |     |     +-- sub_1FCD10 NOT called (no stale values written)
+  |     |
+  |     +-- DialoguePhonemesUpdate
+  |     |     +-- (same -> phoneme1.Reset(), skip interpolation)
+  |     |
+  |     +-- EyesBlinkingUpdate -> blinkValue computed normally
+  |     |
+  |     +-- merge/animMerge(modifier1, modifier2, modifier3)
+  |     |     +-- modifier1 is all zeros -> blinking system drives eyes
+  |     |
+  |     +-- final modifier3 -> eyes blink normally despite WAV still playing
+```
+
+The interpolation call is skipped once the timer exceeds the FaceFX
+animation duration, and `modifier1` is zeroed so the blinking system
+regains control immediately.
+
+## 3. Dialogue data release (phoneme1.timer > animEnd + 0.2s)
+
+```
+KeyframesUpdateHook
+  +-- SmoothUpdate / RegularUpdate
+  |     +-- (modifier1/phoneme1 already zeroed by phase 2)
+  |
+  +-- CheckAndReleaseDialogueData
+        +-- phoneme1.timer > timer threshold -> release
+        +-- ReleaseDialogueData(dialogueData)
+        +-- modifier1.Reset()    <-- safety net
+        +-- phoneme1.Reset()     <-- safety net
+        +-- dialogueData = nullptr
+```
+
+`CheckAndReleaseDialogueData` runs outside the spinlock, after
+`SmoothUpdate`/`RegularUpdate`. The `Reset()` calls here are a safety net
+in case the phase-2 clearing was bypassed (e.g. refCount state prevented
+`DialogueModifiersUpdate` from running).
+
+`Reset()` only zeros the `values` array and `isUpdated` flag -- it does
+not touch the `timer` field, so the `phoneme1.timer` comparison that gates
+the release decision is unaffected.
+
+## 4. No dialogue (dialogueData == nullptr)
+
+```
+KeyframesUpdateHook
+  +-- SmoothUpdate / RegularUpdate
+  |     +-- DialogueModifiersUpdate
+  |     |     +-- dialogueData == nullptr -> return (unchanged)
+  |     |          modifier1.values already zero from phase 2/3
+  |     |
+  |     +-- EyesBlinkingUpdate -> normal blink cycle
+  |     |
+  |     +-- merge/animMerge -> modifier1 all zeros -> no override
+  |     |
+  |     +-- blinking system has full control
+```
+
+No changes needed here. Once `modifier1` is zeroed during phase 2 or 3,
+the values stay zero because `DialogueModifiersUpdate` returns early
+when `dialogueData` is null.

--- a/src/mfgfix/ActorManager.h
+++ b/src/mfgfix/ActorManager.h
@@ -3,6 +3,8 @@
 
 namespace MfgFix
 {
+    class BSFaceGenAnimationData;
+
     class ActorManager
     {
       public:

--- a/src/mfgfix/BSFaceGenAnimationData.cpp
+++ b/src/mfgfix/BSFaceGenAnimationData.cpp
@@ -69,15 +69,20 @@ namespace MfgFix
         if (!dialogueData || (((dialogueData->refCount & 0x70000000) + 0xD0000000) & 0xEFFFFFFF) != 0) {
             return;
         }
+
+        modifier1.timer += a_timeDelta;
+
+        auto animEnd = (dialogueData->unk28->unk0 + (dialogueData->unk28->unk4 < 0 ? -dialogueData->unk28->unk4 : 0)) * 0.033f;
+        if (modifier1.timer > animEnd) {
+            modifier1.Reset();
+            return;
+        }
+
         if (REL::Module::IsVR()) {
             REL::Relocation<bool(void*, float, float*)> sub_1FCD10{ REL::Offset(0x202120) };
-
-            modifier1.timer += a_timeDelta;
             sub_1FCD10(dialogueData->unk28, modifier1.timer, modifier1.values);
         } else {
             REL::Relocation<bool(void*, float, float*)> sub_1FCD10{ RELOCATION_ID(16024, 16267) };
-
-            modifier1.timer += a_timeDelta;
             sub_1FCD10(dialogueData->unk28, modifier1.timer, modifier1.values);
         }
     }
@@ -88,14 +93,19 @@ namespace MfgFix
             return;
         }
 
+        phoneme1.timer += a_timeDelta;
+
+        auto animEnd = (dialogueData->unk28->unk0 + (dialogueData->unk28->unk4 < 0 ? -dialogueData->unk28->unk4 : 0)) * 0.033f;
+        if (phoneme1.timer > animEnd) {
+            phoneme1.Reset();
+            return;
+        }
+
         if (REL::Module::IsVR()) {
             REL::Relocation<bool(void*, float, float*)> sub_1FC9B0{ REL::Offset(0x201d80) };
-            phoneme1.timer += a_timeDelta;
             sub_1FC9B0(dialogueData->unk28, phoneme1.timer, phoneme1.values);
         } else {
             REL::Relocation<bool(void*, float, float*)> sub_1FC9B0{ RELOCATION_ID(16023, 16266) };
-
-            phoneme1.timer += a_timeDelta;
             sub_1FC9B0(dialogueData->unk28, phoneme1.timer, phoneme1.values);
         }
     }
@@ -126,6 +136,8 @@ namespace MfgFix
             ReleaseDialogueData((void*)(loc.address() + 0x100), dialogueData);
         }
 
+        modifier1.Reset();
+        phoneme1.Reset();
         dialogueData = nullptr;
     }
 
@@ -174,6 +186,11 @@ namespace MfgFix
             {
                 if (unk21A) {
                     blinkValue = settings.eyesBlinking.fBlinkDownTime != 0.0f ? 1.0f - eyesBlinkingTimer / settings.eyesBlinking.fBlinkDownTime : 1.0f;
+
+                    if (eyesBlinkingTimer == 0.0f) {
+                        eyesBlinkingStage = EyesBlinkingStage::BlinkUp;
+                        eyesBlinkingTimer = settings.eyesBlinking.fBlinkUpTime;
+                    }
                 } else {
                     blinkValue = 1.0f;
                     eyesBlinkingStage = EyesBlinkingStage::BlinkUp;
@@ -439,7 +456,7 @@ namespace MfgFix
         auto animMerge = [animationStep](Keyframe& dialogue, Keyframe& modifier, Keyframe& result) {
             auto count = min(max(dialogue.count, modifier.count), result.count);
             for (std::uint32_t i = 0; i < count; ++i) {
-                if (i >= modifier.count || fabs(modifier.values[i]) < FLT_EPSILON && fabs(dialogue.values[i]) > FLT_EPSILON) {
+                if (i >= modifier.count || (fabs(modifier.values[i]) < FLT_EPSILON && fabs(dialogue.values[i]) > FLT_EPSILON)) {
                     result.values[i] = dialogue.values[i];
                 } else if (fabs(result.values[i] - modifier.values[i]) < animationStep) {
                     result.values[i] = modifier.values[i];


### PR DESCRIPTION
## Summary

- Fixes a bug where NPC eyes remain closed after dialogue lines whose WAV audio has trailing silence past the FaceFX (LIP) animation data
- Clears stale `modifier1`/`phoneme1` values when the FaceFX timeline ends, and on dialogue data release

## Root cause

When a dialogue line's WAV extends past its FaceFX data, the interpolation functions (`sub_1FCD10`/`sub_1FC9B0`) return the last FaceFX frame's values indefinitely. If that frame has non-zero BlinkLeft/BlinkRight, `modifier1` retains them and the merge/animMerge logic in `RegularUpdate`/`SmoothUpdate` overrides the blinking system — keeping eyes shut until new dialogue data arrives or `mfg reset` is called.

## Fix

- `DialogueModifiersUpdate` / `DialoguePhonemesUpdate`: when `timer > animEnd`, call `Reset()` and skip the interpolation call entirely (no stale values written, no wasted work)
- `CheckAndReleaseDialogueData`: `Reset()` both `modifier1` and `phoneme1` before nulling `dialogueData` (safety net for cases where the update functions didn't run, e.g. refCount gating)

`Reset()` only zeros the `values` array and `isUpdated` flag — it does not touch the `timer` field, so the `phoneme1.timer` comparison that gates dialogue release is unaffected.

Early-return paths (no `dialogueData` / invalid refCount) are left unchanged to avoid one-frame visual pops during transient state transitions.

## Test plan

- [ ] Install on Skyrim SE/AE 1.6.1170 with SKSE 64 2.2.4
- [ ] Speak to an NPC with a dialogue line containing trailing WAV silence past the LIP data end
- [ ] Verify eyes no longer remain closed after the last phoneme fires
- [ ] Verify normal blinking continues during and after dialogue
- [ ] Verify lip sync still works correctly during dialogue